### PR TITLE
Switching to Carriers.boxedComponentValueArray

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -3521,62 +3521,17 @@ return mh1;
          */
         public MethodHandle unreflectDeconstructor(Deconstructor<?> d) throws IllegalAccessException {
             Class<?> ownerType = d.getDeclaringClass(); // Implicit null-check of d
-            final MethodHandle deconstructorPhysicalHandle;
             try {
-                deconstructorPhysicalHandle = unreflect(
-                        ownerType.getDeclaredMethod(
-                                SharedSecrets.getJavaLangReflectAccess().getMangledName(d),
-                                ownerType
-                        )
+                MethodHandle unreflected = unreflect(
+                    ownerType.getDeclaredMethod(
+                        SharedSecrets.getJavaLangReflectAccess().getMangledName(d),
+                        ownerType
+                    )
                 );
+                return unreflected.asType(unreflected.type().changeReturnType(Object.class));
             } catch (NoSuchMethodException | SecurityException ex) {
                 throw new InternalError(ex);
             }
-
-            MethodType bindingType = MethodType.methodType(Object.class,
-                    Arrays.stream(d.getPatternBindings()).map(PatternBinding::getType).toArray(Class<?>[]::new)
-            );
-
-            MethodType boxingType = MethodType.methodType(Object.class, Object.class);
-
-            return filterReturnValue(
-                    deconstructorPhysicalHandle,
-                    permuteArguments(
-                            filterArguments(
-                                    identity(Object.class).asCollector(Object[].class, bindingType.parameterCount()),
-                                    0,
-                                    Carriers.components(bindingType)
-                                            .stream()
-                                            .map(c -> c.asType(boxingType))
-                                            .toArray(MethodHandle[]::new)
-                            ),
-                            boxingType,
-                            new int[bindingType.parameterCount()]
-                    )
-            ).asType(MethodType.methodType(Object[].class, ownerType)); // required for invokeExact
-        }
-
-        private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
-        private static MethodHandle CARRIER_TO_ARRAY;
-
-        static {
-            try {
-                CARRIER_TO_ARRAY = LOOKUP.findStatic(Lookup.class, "carrier2Array",
-                                               MethodType.methodType(Object[].class, Object.class, List.class));
-            } catch (ReflectiveOperationException e) {
-                throw new ExceptionInInitializerError(e);
-            }
-        }
-
-        private static Object[] carrier2Array(Object carrier, List<MethodHandle> componentHandles) throws Throwable {
-            Object[] result = new Object[componentHandles.size()];
-            int i = 0;
-
-            for (MethodHandle componentAccessor : componentHandles) {
-                result[i++] = componentAccessor.invoke(carrier);
-            }
-
-            return result;
         }
 
         /*

--- a/src/java.base/share/classes/java/lang/runtime/Carriers.java
+++ b/src/java.base/share/classes/java/lang/runtime/Carriers.java
@@ -962,4 +962,24 @@ public final class Carriers {
         return component;
     }
 
+    /**
+     * {@return a {@link MethodHandle MethodHandle} which accepts a carrier object
+     * matching the given {@code methodType} which when invoked will return a newly
+     * created object array containing the boxed component values of the carrier object.}
+     *
+     * @param methodType  {@link MethodType} whose parameter types supply the shape of the
+     *                    carrier's components
+     */
+    public static MethodHandle boxedComponentValueArray(MethodType methodType) {
+        var boxingType = MethodType.methodType(Object.class, Object.class);
+        return MethodHandles.permuteArguments(
+            MethodHandles.filterArguments(
+                MethodHandles.identity(Object.class).asCollector(Object[].class, methodType.parameterCount()),
+                0,
+                CarrierFactory.of(methodType).components.stream().map(c -> c.asType(boxingType)).toArray(MethodHandle[]::new)
+            ),
+            boxingType,
+            new int[methodType.parameterCount()]
+        ).asType(boxingType.changeReturnType(Object[].class));
+    }
 }


### PR DESCRIPTION
This change reverts so that unreflected Deconstructors produce CarrierObjects, but introduces a combinator/utility method in Carriers which allows Deconstructor::invoke to return an Object array with the boxed representations.