### PR TITLE
Add extra parameter for initialized carrier

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -2157,11 +2157,14 @@ public final class Class<T> implements java.io.Serializable,
     }
 
     private Deconstructor<?>[] getDeclaredDeconstructors0(Class<?>[] params, int which) {
-        ArrayList<Deconstructor<?>> decs = new ArrayList<>();
         if (this.isPrimitive()) return new Deconstructor<?>[0];
-        try(InputStream is = ClassLoader.getSystemResourceAsStream(getResourcePath())) {
-            byte[] bytes = is.readAllBytes();
+        try (var in = (getClassLoader() != null)
+                ? getClassLoader().getResourceAsStream(getResourcePath())
+                : ClassLoader.getSystemResourceAsStream(getResourcePath())) {
+            if (in == null) throw new RuntimeException("Resource not found: " + name);
+            byte[] bytes = in.readAllBytes();
             ClassModel cm = ClassFile.of().parse(bytes);
+            ArrayList<Deconstructor<?>> decs = new ArrayList<>();
             for (MethodModel mm : cm.methods()) {
                 PatternAttribute pa = mm.findAttribute(Attributes.pattern()).orElse(null);
                 if (pa != null) {
@@ -2182,8 +2185,8 @@ public final class Class<T> implements java.io.Serializable,
                         descriptorFilter = MethodTypeDesc.of(CD_void, paramDescs).descriptorString();
                     }
 
-                    if ((params.length == 0 || (params.length != 0 && pa.patternTypeSymbol().descriptorString().equals(descriptorFilter))) &&
-                        (which == Member.DECLARED || mm.flags().has(AccessFlag.PUBLIC))) {
+                    if ((params.length == 0 || pa.patternTypeSymbol().descriptorString().equals(descriptorFilter)) &&
+                            (which == Member.DECLARED || mm.flags().has(AccessFlag.PUBLIC))) {
                         // binding annotations
                         RuntimeVisibleAnnotationsAttribute rva = mm.findAttribute(Attributes.runtimeVisibleAnnotations()).orElse(null);
                         ByteBuffer assembled_rva = getAnnotationContents(rva != null, (BoundAttribute) rva);
@@ -2226,11 +2229,10 @@ public final class Class<T> implements java.io.Serializable,
                     }
                 }
             }
+            return decs.toArray(new Deconstructor<?>[decs.size()]);
         } catch (IOException | ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
-
-        return decs.toArray(new Deconstructor<?>[decs.size()]);
     }
 
     private String getResourcePath() {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -3361,7 +3361,7 @@ return mh1;
                 return unreflect(
                     ownerType.getDeclaredMethod(
                         SharedSecrets.getJavaLangReflectAccess().getMangledName(d),
-                        ownerType
+                        ownerType, MethodHandle.class
                     )
                 );
             } catch (NoSuchMethodException | SecurityException ex) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -32,8 +32,6 @@ import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Kinds;
 import com.sun.tools.javac.code.Kinds.Kind;
 
-import static com.sun.tools.javac.code.TypeTag.*;
-
 import com.sun.tools.javac.code.Preview;
 import com.sun.tools.javac.code.Source;
 import com.sun.tools.javac.code.Symbol;
@@ -410,13 +408,31 @@ public class TransPatterns extends TreeTranslator {
         Assert.check(recordPattern.patternDeclaration != null);
 
         if (allowPatternDeclarations) {
+            // Generate:
+            //     1. calculate the returnType MethodType as Constant_MethodType_info
+            //     2. generate factory code on carrier for the types we want (e.g., Object carrier = Carriers.initializingConstructor(returnType);)
+            //     3. generate invoke call to pass the bindings (e.g, return carrier.invoke(x, y);)
+            MethodSymbol factoryMethodSym =
+                    rs.resolveInternalMethod(recordPattern.pos(),
+                            env,
+                            syms.carriersType,
+                            names.fromString("initializingConstructor"),
+                            List.of(syms.methodTypeType),
+                            List.nil());
+            DynamicVarSymbol factoryMethodDynamicVar =
+                    (DynamicVarSymbol) invokeMethodWrapper(
+                            names.fromString("carrier"),
+                            recordPattern.pos(),
+                            factoryMethodSym.asHandle(),
+                            new MethodType(recordPattern.patternDeclaration.type.getBindingTypes(), syms.objectType, List.nil(), syms.methodClass));
+
             mSymbol = new BindingSymbol(Flags.SYNTHETIC,
                     names.fromString(target.syntheticNameChar() + "m" + target.syntheticNameChar() + variableIndex++), syms.objectType,
                     currentMethodSym);
             JCVariableDecl mVar = make.VarDef(mSymbol, null);
 
             firstLevelChecks = make.TypeTest(
-                    generatePatternCall(recordPattern, tempBind),
+                    generatePatternCall(recordPattern, tempBind, factoryMethodDynamicVar),
                     make.BindingPattern(mVar).setType(mSymbol.type)).setType(syms.booleanType);
 
             // Resolve Carriers.component(methodType, index) for subsequent constant dynamic call results
@@ -534,7 +550,7 @@ public class TransPatterns extends TreeTranslator {
         return new UnrolledRecordPattern((JCBindingPattern) make.BindingPattern(recordBindingVar).setType(recordBinding.type), guard);
     }
 
-    private JCMethodInvocation generatePatternCall(JCRecordPattern recordPattern, BindingSymbol matchCandidate) {
+    private JCMethodInvocation generatePatternCall(JCRecordPattern recordPattern, BindingSymbol matchCandidate, DynamicVarSymbol factoryMethodDynamicVar) {
         List<Type> staticArgTypes = List.of(syms.methodHandleLookupType,
                 syms.stringType,
                 syms.methodTypeType,
@@ -549,16 +565,16 @@ public class TransPatterns extends TreeTranslator {
 
         // deconstructors, instance patterns and static patterns
         if (recordPattern.deconstructor instanceof JCFieldAccess acc && !TreeInfo.isStaticSelector(acc.selected, names)) {
-                                           /*receiver                , match candidate            */
-            invocationParamTypes = List.of(acc.selected.type         , recordPattern.type);
-            invocationParams     = List.of(acc.selected              , make.Ident(matchCandidate));
+                                           /*receiver                , match candidate              carrier method handle */
+            invocationParamTypes = List.of(acc.selected.type         , recordPattern.type,          factoryMethodDynamicVar.type);
+            invocationParams     = List.of(acc.selected              , make.Ident(matchCandidate),  make.Ident(factoryMethodDynamicVar));
         } else if (!recordPattern.patternDeclaration.isStatic() && !recordPattern.patternDeclaration.isDeconstructor()) {
-            invocationParamTypes = List.of(recordPattern.type        , recordPattern.type);
-            invocationParams     = List.of(make.Ident(matchCandidate), make.Ident(matchCandidate));
+            invocationParamTypes = List.of(recordPattern.type        , recordPattern.type,          factoryMethodDynamicVar.type);
+            invocationParams     = List.of(make.Ident(matchCandidate), make.Ident(matchCandidate),  make.Ident(factoryMethodDynamicVar));
         }
         else {
-            invocationParams     = List.of(make.Ident(matchCandidate));
-            invocationParamTypes = List.of(recordPattern.type);
+            invocationParamTypes = List.of(recordPattern.type, factoryMethodDynamicVar.type);
+            invocationParams     = List.of(make.Ident(matchCandidate), make.Ident(factoryMethodDynamicVar) );
         }
         MethodType indyType = new MethodType(
                 invocationParamTypes,
@@ -1006,7 +1022,6 @@ public class TransPatterns extends TreeTranslator {
      * <pre>{@code
      *     binding1 = arg1;
      *     binding2 = arg2;
-     *     return carrier.invoke(binding1, binding2);
      * }</pre>
      *
      */
@@ -1019,27 +1034,10 @@ public class TransPatterns extends TreeTranslator {
 
         ListBuffer<JCStatement> stats = new ListBuffer<>();
 
-        // Generate:
-        //     1. calculate the returnType MethodType as Constant_MethodType_info
-        //     2. generate factory code on carrier for the types we want (e.g., Object carrier = Carriers.initializingConstructor(returnType);)
-        //     3. generate invoke call to pass the bindings (e.g, return carrier.invoke(x, y);)
-        MethodSymbol factoryMethodSym =
-                rs.resolveInternalMethod(tree.pos(),
-                        env,
-                        syms.carriersType,
-                        names.fromString("initializingConstructor"),
-                        List.of(syms.methodTypeType),
-                        List.nil());
-
-        DynamicVarSymbol factoryMethodDynamicVar =
-                (DynamicVarSymbol) invokeMethodWrapper(
-                        names.fromString("carrier"),
-                        tree.pos(),
-                        factoryMethodSym.asHandle(),
-                        new MethodType(tree.meth.type.getBindingTypes(), syms.objectType, List.nil(), syms.methodClass));
-
+        // force the evaluation of each parameter to match
         // Generate:
         //      parameter1 = arg1;
+        //      ...
         while (matchArguments.nonEmpty() && bindings.nonEmpty() && bindingTypes.nonEmpty()) {
             JCExpressionStatement stat =
                     make.Exec(make.Assign(make.Ident(bindings.head),
@@ -1053,12 +1051,10 @@ public class TransPatterns extends TreeTranslator {
             matchArguments = matchArguments.tail;
         }
 
-        JCIdent factoryMethodCall = make.Ident(factoryMethodDynamicVar);
+        // the same parameters must be passed to the carrier.invoke(<carrier arguments>)
+        // that is emitted in Lower:visitMethodDef
+        tree.meth.carrierArguments = invokeMethodParam;
 
-        JCMethodInvocation invokeMethodCall =
-                makeApply(factoryMethodCall, names.fromString("invoke"), invokeMethodParam);
-
-        stats = stats.append(make.Return(invokeMethodCall));
         result = make.at(tree.pos).Block(0, stats.toList());
     }
 
@@ -1456,10 +1452,6 @@ public class TransPatterns extends TreeTranslator {
             currentMethodSym = tree.sym;
             variableIndex = 0;
             deconstructorCalls = null;
-            if (tree.sym.isPattern()) {
-                tree.body.stats = tree.body.stats.append(
-                    make.Throw(makeNewClass(syms.matchExceptionType, List.of(makeNull(), makeNull()))));
-            }
             super.visitMethodDef(tree);
             preparePatternMatchingCatchIfNeeded(tree.body);
         } finally {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -937,6 +937,8 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         public List<JCVariableDecl> bindings;
         /** match candidate parameter */
         public JCVariableDecl matchcandparam;
+        /** collected carrier arguments from the match call */
+        public  List<JCExpression> carrierArguments;
         /** exceptions thrown by this method */
         public List<JCExpression> thrown;
         /** statements in the method */

--- a/test/jdk/java/lang/invoke/lookup/UnreflectPattern.java
+++ b/test/jdk/java/lang/invoke/lookup/UnreflectPattern.java
@@ -47,14 +47,17 @@ public class UnreflectPattern {
         }
         MethodHandle unreflected =
                 MethodHandles.lookup().unreflectDeconstructor(deconstructor);
-        if (!MethodType.methodType(Object.class, UnreflectPattern.class).equals(unreflected.type()))
+        if (!MethodType.methodType(Object.class, UnreflectPattern.class, MethodHandle.class).equals(unreflected.type()))
             throw new AssertionError("Unexpected type: " + unreflected.type());
+        MethodType bindingMT = MethodType.methodType(Object.class, String.class, Integer.TYPE);
         MethodHandle deconstructorHandle =
             MethodHandles.filterReturnValue(
                 unreflected,
-                Carriers.boxedComponentValueArray(MethodType.methodType(Object.class, String.class, Integer.TYPE))
+                Carriers.boxedComponentValueArray(bindingMT)
             );
-        Object[] result2 = (Object[]) deconstructorHandle.invokeExact(instance);
+        MethodHandle initializingConstructor = Carriers.initializingConstructor(bindingMT);
+
+        Object[] result2 = (Object[]) deconstructorHandle.invokeExact(instance, initializingConstructor);
         if (!Arrays.equals(expected, result2)) {
             throw new AssertionError("Unexpected result: " + Arrays.toString(result2));
         }

--- a/test/jdk/java/lang/runtime/PatternBootstrapsTest.java
+++ b/test/jdk/java/lang/runtime/PatternBootstrapsTest.java
@@ -81,10 +81,13 @@ public class PatternBootstrapsTest {
     }
 
     private void testPatternInvocation(Object target, Class<?> targetType, String mangledName, int componentNo, int result) throws Throwable {
-        MethodType dtorType = MethodType.methodType(Object.class, targetType);
+        MethodType dtorType = MethodType.methodType(Object.class, targetType, MethodHandle.class);
         MethodHandle indy = ((CallSite) INVK_PATTERN.invoke(MethodHandles.lookup(), "", dtorType, mangledName)).dynamicInvoker();
-        List<MethodHandle> components = Carriers.components(MethodType.methodType(Object.class, int.class, int.class));
-        assertEquals((int) components.get(componentNo).invokeExact(indy.invoke(target)), result);
+
+        MethodType bindingMT = MethodType.methodType(Object.class, int.class, int.class);
+        MethodHandle initializingConstructor = Carriers.initializingConstructor(bindingMT);
+        List<MethodHandle> components = Carriers.components(bindingMT);
+        assertEquals((int) components.get(componentNo).invokeExact(indy.invoke(target, initializingConstructor)), result);
     }
 
     public void testPatternInvocations() throws Throwable {

--- a/test/langtools/tools/javac/patterns/declarations/PatternDeclarationsBytecodeTest.java
+++ b/test/langtools/tools/javac/patterns/declarations/PatternDeclarationsBytecodeTest.java
@@ -94,7 +94,7 @@ public class PatternDeclarationsBytecodeTest extends TestRunner  {
                     .run()
                     .getOutput(Task.OutputKind.DIRECT);
 
-            if (!javapOut.contains("public static java.lang.Object \\^dinit\\_:Test:Ljava\\|lang\\|String\\?:Ljava\\|lang\\|String\\?(test.Test)"))
+            if (!javapOut.contains("public static java.lang.Object \\^dinit\\_:Test:Ljava\\|lang\\|String\\?:Ljava\\|lang\\|String\\?(test.Test, java.lang.invoke.MethodHandle)"))
                 throw new AssertionError("Wrongly generated signature of pattern declaration:\n" + javapOut);
         }
     }
@@ -143,7 +143,7 @@ public class PatternDeclarationsBytecodeTest extends TestRunner  {
                     .getOutput(Task.OutputKind.DIRECT);
 
             String[] outputs = {
-                    "Signature: #36                          // (Ljava/util/Collection<Ljava/lang/Integer;>;Ljava/util/Collection<Ljava/lang/Integer;>;)V",
+                    "Signature: #32                          // (Ljava/util/Collection<Ljava/lang/Integer;>;Ljava/util/Collection<Ljava/lang/Integer;>;)V",
             };
 
             if (!Arrays.stream(outputs).allMatch(o -> javapOut.contains(o)))
@@ -201,10 +201,10 @@ public class PatternDeclarationsBytecodeTest extends TestRunner  {
             String o = """
                     RuntimeVisibleParameterAnnotations:
                             parameter 0:
-                              0: #35()
+                              0: #31()
                                 test.Test$BindingAnnotation
                             parameter 1:
-                              0: #35()
+                              0: #31()
                                 test.Test$BindingAnnotation
                     """;
 


### PR DESCRIPTION
### Existing Approach

Currently the pattern-declaration and pattern-use site look like the following: 

- Pattern-declaration site

Currently, on the pattern-declaration site the carrier creation is taking place inside the method site:

```java
pattern Point(int x, int y) {
    match Point(1, 2);
}
// translates to
static Object \^dinit\_:Point:I:I(ClassPatternDeclarations$Point) {
    int x = 1;
    int y = 2;
    Object carrier = <ldc> [static returnType =  MethodType.methodType(Object.class, int.class, int.class)] Carriers.initializingConstructor(returnType);
    return carrier.invoke(x, y);
}
```

- Pattern-use site

Let's observe how a pattern site is translated:

```java
o instanceof Point(int x, int y)
// translates to
Point p = (Point) o;
Carrier c = <invokedynamic> <ConstantCallSite(Point.\^dinit\_:Point:I:I(p))>; // ConstantCallSite calculated from PatternBootstrap
...
MethodHandle component$0 = <ldc> [static arg = MethodType.methodType(Object.class, int.class, int.class)] Carriers.component(arg, 0);
MethodHandle component$1 = <ldc> [static arg = MethodType.methodType(Object.class, int.class, int.class)] Carriers.component(arg, 1);
...
int $0 = component$0.invoke(c);
// safeguard the cast for x -- identity here
int $1 = component$1.invoke(c);
// safeguard the cast for y -- also identity here
...
```

### Adjustment 

This PR adds one extra parameter on all translated methods in the end (the deconstructor/static method, the instance pattern/instance method, and the static pattern/static method) to decouple the creation of the carrier from the body of the pattern itself.

- New Pattern-declaration site

We introduce an additional `MethodHandle`:

```java
static Object \^dinit\_:Point:I:I(ClassPatternDeclarations$Point, MethodHandle carrier) {
    int x = 1;
    int y = 2;
    return carrier.invoke(x, y);
}
```

- New Pattern-use site

The extractor should be calculated and shared per client use-site:

```java
o instanceof Point(int x, int y)
// translates to
Point p = (Point) o;
...
MethodHandle carrierExtractor = <ldc>[static arg = MethodType.methodType(Object.class, int.class, int.class)] Carriers.initializingConstructor(arg);
Carrier c = <invokedynamic> <ConstantCallSite(Point.\^dinit\_:Point:I:I(p, carrierExtractor))>; // ConstantCallSite calculated from PatternBootstrap
...
MethodHandle component$0 = <ldc> [static arg = MethodType.methodType(Object.class, int.class, int.class)] Carriers.component(arg, 0);
MethodHandle component$1 = <ldc> [static arg = MethodType.methodType(Object.class, int.class, int.class)] Carriers.component(arg, 1);
...
int $0 = component$0.invoke(c);
// safeguard the cast for x -- identity here
int $1 = component$1.invoke(c);
// safeguard the cast for y -- also identity here
...
````